### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         node-version:
           - 16
           - 14
-          - 12
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jpegoptim": "cli.js"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "scripts": {
     "postinstall": "node lib/install.js",


### PR DESCRIPTION
Node.js 12 is now outdated ([2022-04-30](https://nodejs.org/en/about/releases/)).